### PR TITLE
Add playsInline to Player <video>

### DIFF
--- a/packages/core/src/PlayerContextProvider.js
+++ b/packages/core/src/PlayerContextProvider.js
@@ -791,6 +791,7 @@ export class PlayerContextProvider extends Component {
       <Fragment>
         <video
           hidden
+          playsInline
           ref={this.setMediaElementRef}
           crossOrigin={this.props.crossOrigin}
           preload="metadata"


### PR DESCRIPTION
Have a read: https://webkit.org/blog/6784/new-video-policies-for-ios/

> <video> elements without playsinline attributes will continue to require fullscreen mode for playback on iPhone.

Without this attribute, a full screen player is opened on iOS, not exactly what one wants when building its own player 😅. Do you prefer to have this as in the PR, or as a prop, or be able to pass props to the <video> component (would be spread before important handlers)?