### PR TITLE
Issue/308 peer to normal deps

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -39,15 +39,14 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "@cassette/core": "2.0.0-alpha.3",
     "react": "^16.3.0"
   },
   "devDependencies": {
-    "@cassette/core": "^2.0.0-alpha.6",
     "rimraf": "^2.5.4",
     "webpack": "^4.17.1"
   },
   "dependencies": {
+    "@cassette/core": "^2.0.0-alpha.6",
     "prop-types": "^15.5.10",
     "resize-observer-polyfill": "^1.4.2"
   },

--- a/packages/core/src/FullscreenContext.js
+++ b/packages/core/src/FullscreenContext.js
@@ -1,8 +1,7 @@
-import { createContext } from 'react';
-
+import createSingleGlobalContext from './utils/createSingleGlobalContext';
 import { logWarning } from './utils/console';
 
-const FullscreenContext = createContext({
+export default createSingleGlobalContext('FullscreenContext', {
   fullscreen: false,
   requestFullscreen() {
     logWarning(
@@ -17,6 +16,3 @@ const FullscreenContext = createContext({
     );
   }
 });
-FullscreenContext.displayName = 'FullscreenContext';
-
-export default FullscreenContext;

--- a/packages/core/src/GroupContext.js
+++ b/packages/core/src/GroupContext.js
@@ -1,6 +1,3 @@
-import { createContext } from 'react';
+import createSingleGlobalContext from './utils/createSingleGlobalContext';
 
-const GroupContext = createContext(null);
-GroupContext.displayName = 'GroupContext';
-
-export default GroupContext;
+export default createSingleGlobalContext('GroupContext');

--- a/packages/core/src/PlayerContext.js
+++ b/packages/core/src/PlayerContext.js
@@ -1,6 +1,3 @@
-import { createContext } from 'react';
+import createSingleGlobalContext from './utils/createSingleGlobalContext';
 
-const PlayerContext = createContext(null);
-PlayerContext.displayName = 'PlayerContext';
-
-export default PlayerContext;
+export default createSingleGlobalContext('PlayerContext');

--- a/packages/core/src/utils/createSingleGlobalContext.js
+++ b/packages/core/src/utils/createSingleGlobalContext.js
@@ -1,0 +1,16 @@
+import { createContext } from 'react';
+
+const _global = typeof window === 'undefined' ? global : window;
+_global.__player_context_created__ = _global.__player_context_created__ || {};
+
+function createSingleGlobalContext(displayName, defaultValue = null) {
+  if (_global.__player_context_created__[displayName]) {
+    return _global.__player_context_created__[displayName];
+  }
+  const Context = createContext(defaultValue);
+  Context.displayName = displayName;
+  _global.__player_context_created__[displayName] = Context;
+  return Context;
+}
+
+export default createSingleGlobalContext;

--- a/packages/core/src/utils/createSingleGlobalContext.js
+++ b/packages/core/src/utils/createSingleGlobalContext.js
@@ -1,15 +1,28 @@
 import { createContext } from 'react';
 
+import { logWarning } from './console';
+
+const packageVersion = require('../../package.json').version;
+
 const _global = typeof window === 'undefined' ? global : window;
-_global.__player_context_created__ = _global.__player_context_created__ || {};
+_global.__cassette_contexts__ = _global.__cassette_contexts__ || {};
 
 function createSingleGlobalContext(displayName, defaultValue = null) {
-  if (_global.__player_context_created__[displayName]) {
-    return _global.__player_context_created__[displayName];
+  const ExistingContext = _global.__cassette_contexts__[displayName];
+  if (ExistingContext) {
+    if (ExistingContext.packageVersion !== packageVersion) {
+      logWarning(
+        `Warning: multiple versions of ${displayName} from the @cassette/core` +
+          ` package have been loaded. v${packageVersion} will be ignored and` +
+          ` v${ExistingContext.packageVersion} will be used instead.`
+      );
+    }
+    return ExistingContext;
   }
   const Context = createContext(defaultValue);
   Context.displayName = displayName;
-  _global.__player_context_created__[displayName] = Context;
+  Context.packageVersion = packageVersion;
+  _global.__cassette_contexts__[displayName] = Context;
   return Context;
 }
 

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -40,11 +40,9 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "@cassette/core": "2.0.0-alpha.3",
     "react": "^16.3.0"
   },
   "devDependencies": {
-    "@cassette/core": "^2.0.0-alpha.6",
     "gulp-cli": "^2.0.1",
     "material-design-icons": "^3.0.1",
     "rimraf": "^2.5.4",
@@ -52,6 +50,7 @@
   },
   "dependencies": {
     "@cassette/components": "^2.0.0-alpha.6",
+    "@cassette/core": "^2.0.0-alpha.6",
     "prop-types": "^15.5.10"
   },
   "publishConfig": {


### PR DESCRIPTION
Closes #308.

Now everything in cassette is a normal dependency and we create single global copies of each context instead of loading them separately when there are multiple versions. If the versions are different, we'll emit a warning to the javascript console.