### PR TITLE
Don't remove listeners if media element isn't created

### DIFF
--- a/packages/core/src/PlayerContextProvider.js
+++ b/packages/core/src/PlayerContextProvider.js
@@ -412,22 +412,32 @@ export class PlayerContextProvider extends Component {
 
   componentWillUnmount() {
     const { media } = this;
-    // remove listeners for media events
-    media.removeEventListener('play', this.handleMediaPlay);
-    media.removeEventListener('pause', this.handleMediaPause);
-    media.removeEventListener('ended', this.handleMediaEnded);
-    media.removeEventListener('stalled', this.handleMediaStalled);
-    media.removeEventListener('canplaythrough', this.handleMediaCanplaythrough);
-    media.removeEventListener('timeupdate', this.handleMediaTimeupdate);
-    media.removeEventListener('loadedmetadata', this.handleMediaLoadedmetadata);
-    media.removeEventListener('volumechange', this.handleMediaVolumechange);
-    media.removeEventListener('durationchange', this.handleMediaDurationchange);
-    media.removeEventListener('progress', this.handleMediaProgress);
-    media.removeEventListener('ratechange', this.handleMediaRatechange);
-    // remove special event listeners on the media element
-    media.removeEventListener('srcrequest', this.handleMediaSrcrequest);
-    media.removeEventListener('loopchange', this.handleMediaLoopchange);
-
+    if (media) {
+      // remove listeners for media events
+      media.removeEventListener('play', this.handleMediaPlay);
+      media.removeEventListener('pause', this.handleMediaPause);
+      media.removeEventListener('ended', this.handleMediaEnded);
+      media.removeEventListener('stalled', this.handleMediaStalled);
+      media.removeEventListener(
+        'canplaythrough',
+        this.handleMediaCanplaythrough
+      );
+      media.removeEventListener('timeupdate', this.handleMediaTimeupdate);
+      media.removeEventListener(
+        'loadedmetadata',
+        this.handleMediaLoadedmetadata
+      );
+      media.removeEventListener('volumechange', this.handleMediaVolumechange);
+      media.removeEventListener(
+        'durationchange',
+        this.handleMediaDurationchange
+      );
+      media.removeEventListener('progress', this.handleMediaProgress);
+      media.removeEventListener('ratechange', this.handleMediaRatechange);
+      // remove special event listeners on the media element
+      media.removeEventListener('srcrequest', this.handleMediaSrcrequest);
+      media.removeEventListener('loopchange', this.handleMediaLoopchange);
+    }
     clearTimeout(this.gapLengthTimeout);
     clearTimeout(this.delayTimeout);
   }
@@ -1026,7 +1036,9 @@ export class PlayerContextGroupMember extends Component {
   }
 
   componentWillUnmount() {
-    this.props.groupContext.unregisterMediaElement(this.mediaElement);
+    if (this.mediaElement) {
+      this.props.groupContext.unregisterMediaElement(this.mediaElement);
+    }
   }
 
   render() {

--- a/packages/core/src/PlayerContextProvider.js
+++ b/packages/core/src/PlayerContextProvider.js
@@ -412,6 +412,7 @@ export class PlayerContextProvider extends Component {
 
   componentWillUnmount() {
     const { media } = this;
+    // Media element might not exist if MutationObserver isn't supported by the browser
     if (media) {
       // remove listeners for media events
       media.removeEventListener('play', this.handleMediaPlay);
@@ -1036,6 +1037,7 @@ export class PlayerContextGroupMember extends Component {
   }
 
   componentWillUnmount() {
+    // Media element might not exist if MutationObserver isn't supported by the browser
     if (this.mediaElement) {
       this.props.groupContext.unregisterMediaElement(this.mediaElement);
     }

--- a/packages/core/src/PlayerContextProvider.js
+++ b/packages/core/src/PlayerContextProvider.js
@@ -412,7 +412,10 @@ export class PlayerContextProvider extends Component {
 
   componentWillUnmount() {
     const { media } = this;
-    // Media element might not exist if MutationObserver isn't supported by the browser
+    // Media element creation will have failed if MutationObserver isn't
+    // supported by the browser. The parent might use an Error Boundary
+    // to display a fallback and so we try to avoid triggering *additional*
+    // errors while the component unmounts.
     if (media) {
       // remove listeners for media events
       media.removeEventListener('play', this.handleMediaPlay);
@@ -1037,7 +1040,8 @@ export class PlayerContextGroupMember extends Component {
   }
 
   componentWillUnmount() {
-    // Media element might not exist if MutationObserver isn't supported by the browser
+    // Media element might not exist
+    // (see componentWillUnmount of PlayerContextProvider)
     if (this.mediaElement) {
       this.props.groupContext.unregisterMediaElement(this.mediaElement);
     }


### PR DESCRIPTION
In some cases, media element isn't created, e.g. old browsers don't have `MutationObserver` and so creating it throws an error. If you use an ErrorBoundary you can catch this and render a fallback, but then you also get additional errors when the PlayerContextProvider unmounts, because it tries to remove event listeners of a null media elem.