### PR TITLE
Prevent errors on componentWillUnmount

### DIFF
--- a/packages/components/src/MaybeMarquee.js
+++ b/packages/components/src/MaybeMarquee.js
@@ -51,6 +51,9 @@ export class MaybeMarquee extends PureComponent {
 
   componentWillUnmount() {
     cancelAnimationFrame(this.animationFrameRequest);
+    // resizeObserver creation will have failed if
+    // ResizeObserver isn't supported by the browser.
+    // (see componentWillUnmount of PlayerContextProvider)
     if (this.resizeObserver) {
       this.resizeObserver.disconnect();
     }

--- a/packages/components/src/MaybeMarquee.js
+++ b/packages/components/src/MaybeMarquee.js
@@ -51,7 +51,9 @@ export class MaybeMarquee extends PureComponent {
 
   componentWillUnmount() {
     cancelAnimationFrame(this.animationFrameRequest);
-    this.resizeObserver.disconnect();
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+    }
   }
 
   moveMarquee() {

--- a/packages/components/src/ProgressBar.js
+++ b/packages/components/src/ProgressBar.js
@@ -66,7 +66,11 @@ export class ProgressBar extends PureComponent {
 
     // remove noselect class in case a drag is in progress
     this.toggleNoselect(false);
-    this.noselectStyleElement.parentNode.removeChild(this.noselectStyleElement);
+    if (this.noselectStyleElement) {
+      this.noselectStyleElement.parentNode.removeChild(
+        this.noselectStyleElement
+      );
+    }
   }
 
   setProgressContainerRef(ref) {

--- a/packages/components/src/ProgressBar.js
+++ b/packages/components/src/ProgressBar.js
@@ -66,6 +66,8 @@ export class ProgressBar extends PureComponent {
 
     // remove noselect class in case a drag is in progress
     this.toggleNoselect(false);
+    // noselectStyleElement might not exist if there's an error
+    // before the timeout callback is called.
     if (this.noselectStyleElement) {
       this.noselectStyleElement.parentNode.removeChild(
         this.noselectStyleElement

--- a/packages/components/src/VideoDisplay.js
+++ b/packages/components/src/VideoDisplay.js
@@ -86,6 +86,9 @@ export class VideoDisplay extends PureComponent {
   }
 
   componentWillUnmount() {
+    // containerResizeObserver creation will have failed if
+    // ResizeObserver isn't supported by the browser.
+    // (see componentWillUnmount of PlayerContextProvider)
     if (this.containerResizeObserver) {
       this.containerResizeObserver.disconnect();
     }

--- a/packages/components/src/VideoDisplay.js
+++ b/packages/components/src/VideoDisplay.js
@@ -86,7 +86,9 @@ export class VideoDisplay extends PureComponent {
   }
 
   componentWillUnmount() {
-    this.containerResizeObserver.disconnect();
+    if (this.containerResizeObserver) {
+      this.containerResizeObserver.disconnect();
+    }
     this.props.unregisterVideoHostElement(this.containerElement);
   }
 

--- a/packages/player/src/controls/VolumeControl.js
+++ b/packages/player/src/controls/VolumeControl.js
@@ -111,10 +111,12 @@ export class VolumeControl extends PureComponent {
   }
 
   componentWillUnmount() {
-    this.muteToggleRef.removeEventListener(
-      'touchstart',
-      this.handleMuteToggleTouchStart
-    );
+    if (this.muteToggleRef) {
+      this.muteToggleRef.removeEventListener(
+        'touchstart',
+        this.handleMuteToggleTouchStart
+      );
+    }
     document.removeEventListener('touchstart', this.handleMouseLeave);
   }
 

--- a/packages/player/src/controls/VolumeControl.js
+++ b/packages/player/src/controls/VolumeControl.js
@@ -111,12 +111,10 @@ export class VolumeControl extends PureComponent {
   }
 
   componentWillUnmount() {
-    if (this.muteToggleRef) {
-      this.muteToggleRef.removeEventListener(
-        'touchstart',
-        this.handleMuteToggleTouchStart
-      );
-    }
+    this.muteToggleRef.removeEventListener(
+      'touchstart',
+      this.handleMuteToggleTouchStart
+    );
     document.removeEventListener('touchstart', this.handleMouseLeave);
   }
 


### PR DESCRIPTION
Similar to #342, but for the rest of components that use `componentWillUnmount`, it makes sure that the variables exist before doing their cleaning. 