### PR TITLE
Enable injection of media element into PlayerContextProvider

### DIFF
--- a/packages/core/src/PlayerContextProvider.js
+++ b/packages/core/src/PlayerContextProvider.js
@@ -993,7 +993,7 @@ export class PlayerContextProvider extends Component {
 PlayerContextProvider.propTypes = {
   playlist: PropTypes.arrayOf(PlayerPropTypes.track.isRequired).isRequired,
   autoplay: PropTypes.bool.isRequired,
-  createMediaElement: PropTypes.func,
+  createMediaElement: PropTypes.func.isRequired,
   autoplayDelayInSeconds: PropTypes.number.isRequired,
   gapLengthInSeconds: PropTypes.number.isRequired,
   crossOrigin: PlayerPropTypes.crossOriginAttribute,

--- a/packages/core/src/PlayerContextProvider.js
+++ b/packages/core/src/PlayerContextProvider.js
@@ -205,7 +205,9 @@ export class PlayerContextProvider extends Component {
   }
 
   componentDidMount() {
-    const media = (this.media = createCustomMediaElement());
+    const media = (this.media = createCustomMediaElement(
+      this.props.createMediaElement()
+    ));
 
     const {
       defaultPlaybackRate,
@@ -991,6 +993,7 @@ export class PlayerContextProvider extends Component {
 PlayerContextProvider.propTypes = {
   playlist: PropTypes.arrayOf(PlayerPropTypes.track.isRequired).isRequired,
   autoplay: PropTypes.bool.isRequired,
+  createMediaElement: PropTypes.func,
   autoplayDelayInSeconds: PropTypes.number.isRequired,
   gapLengthInSeconds: PropTypes.number.isRequired,
   crossOrigin: PlayerPropTypes.crossOriginAttribute,
@@ -1024,6 +1027,7 @@ PlayerContextProvider.propTypes = {
 PlayerContextProvider.defaultProps = {
   autoplay: false,
   autoplayDelayInSeconds: 0,
+  createMediaElement: () => document.createElement('video'),
   gapLengthInSeconds: 0,
   defaultVolume: 1,
   defaultMuted: false,

--- a/packages/core/src/factories/createCustomMediaElement.js
+++ b/packages/core/src/factories/createCustomMediaElement.js
@@ -1,8 +1,7 @@
 const loopchange = 'loopchange';
 const srcrequest = 'srcrequest';
 
-function createCustomMediaElement() {
-  const media = document.createElement('video');
+function createCustomMediaElement(media) {
   new MutationObserver(() => {
     media.dispatchEvent(new Event(loopchange));
   }).observe(media, {


### PR DESCRIPTION
So it was pretty simple to enable. After I added it to the context I used the ExamplePlayerContextProvider.js to test that changing the prop to a function that returns null breaks the component like it should, that not including the prop uses the default I set and that injecting another element works as it should.

I wasn't sure what to name the prop so I went with createMediaElement, let me know what you think of that. 

Happy to make changes to fit with what you're thinking.