### PR TITLE
Retry media load if it has Infinity duration.

### DIFF
--- a/packages/core/src/PlayerContextProvider.js
+++ b/packages/core/src/PlayerContextProvider.js
@@ -739,6 +739,7 @@ export class PlayerContextProvider extends Component {
 
   handleMediaDurationchange() {
     const { duration } = this.media;
+    const activeTrack = this.props.playlist[this.state.activeTrackIndex];
     if (duration === Infinity) {
       // This *could* be because we're consuming an unbounded stream.
       // It could also be because of a weird iOS bug that we want to
@@ -746,15 +747,16 @@ export class PlayerContextProvider extends Component {
 
       // If we still end up with Infinity duration multiple times for
       // the same track, we'll assume it's correct.
-      const activeTrack = this.props.playlist[this.state.activeTrackIndex];
-      if (activeTrack === this.activeTrackAtLastDurationChange) {
+      if (
+        activeTrack.isUnboundedStream ||
+        activeTrack === this.activeTrackAtLastDurationChange
+      ) {
         this.setState({
           duration,
           currentTime: 0
         });
         this.media.currentTime = 0;
       } else {
-        this.activeTrackAtLastDurationChange = activeTrack;
         const { paused } = this.state;
         this.media.load();
         if (!paused) {
@@ -768,6 +770,7 @@ export class PlayerContextProvider extends Component {
     } else {
       this.setState({ duration });
     }
+    this.activeTrackAtLastDurationChange = activeTrack;
   }
 
   handleMediaProgress() {

--- a/packages/core/src/PlayerPropTypes.js
+++ b/packages/core/src/PlayerPropTypes.js
@@ -79,6 +79,7 @@ export const track = PropTypes.shape({
   artwork: PropTypes.arrayOf(mediaSessionArtwork.isRequired),
   duration: PropTypes.oneOf([PropTypes.string, PropTypes.number]),
   startingTime: PropTypes.number,
+  isUnboundedStream: PropTypes.bool,
   meta: PropTypes.object
 });
 


### PR DESCRIPTION
Fixes #355.

Tested with an infinite duration stream and ~it seems to not have any noticeable impact on playback~ (http://158.69.114.190:8072/;?1476089829845.mp3, which I found on a site that uses Cassette for radio playback: https://arubapage.com).