### PR TITLE
Issue/366 snapshot changes

### DIFF
--- a/packages/core/src/PlayerContextProvider.js
+++ b/packages/core/src/PlayerContextProvider.js
@@ -1136,9 +1136,7 @@ PlayerContextProvider.propTypes = {
   ).isRequired,
   mediaSessionSeekLengthInSeconds: PropTypes.number.isRequired,
   mediaElementRef: PropTypes.func,
-  initialStateSnapshot: PropTypes.shape({
-    __unstable__: PropTypes.object.isRequired
-  }),
+  initialStateSnapshot: PropTypes.object,
   onStateSnapshot: PropTypes.func,
   onActiveTrackUpdate: PropTypes.func,
   // A function called when the media element's currentTime attribute has changed

--- a/packages/core/src/PlayerContextProvider.js
+++ b/packages/core/src/PlayerContextProvider.js
@@ -125,6 +125,22 @@ export class PlayerContextProvider extends Component {
     if (isPlaylistValid(props.playlist) && props.playlist[activeTrackIndex]) {
       currentTime = props.playlist[activeTrackIndex].startingTime || 0;
     }
+    const { initialStateSnapshot } = props;
+    let restoredStateFromSnapshot = {};
+    if (initialStateSnapshot) {
+      try {
+        restoredStateFromSnapshot = restoreStateFromSnapshot(
+          initialStateSnapshot,
+          props
+        );
+      } catch (err) {
+        logWarning(err);
+        logWarning('Loading Cassette state from snapshot failed.');
+        logWarning(
+          `Failed snapshot:\n${JSON.stringify(initialStateSnapshot, null, 2)}`
+        );
+      }
+    }
     this.state = {
       ...defaultState,
       // index matching requested track (whether track has loaded or not)
@@ -154,9 +170,7 @@ export class PlayerContextProvider extends Component {
       // playlist prop copied to state (for getDerivedStateFromProps)
       __playlist__: props.playlist,
       // load overrides from previously-captured state snapshot
-      ...(props.initialStateSnapshot
-        ? restoreStateFromSnapshot(props.initialStateSnapshot, props)
-        : {})
+      ...restoredStateFromSnapshot
     };
 
     // volume at last time we were unmuted and not actively setting volume

--- a/packages/core/src/utils/snapshot.js
+++ b/packages/core/src/utils/snapshot.js
@@ -2,6 +2,24 @@ import isPlaylistValid from './isPlaylistValid';
 import getTrackSources from './getTrackSources';
 import findTrackIndexByUrl from './findTrackIndexByUrl';
 
+const veryLongKey =
+  '__highly_unstable_snapshot_internals_which_will_break_your_app_if_you_use_them_directly__';
+const versionKey = '__cassette_snapshot_version__';
+
+// IMPORTANT: new migrations *must* always be added to the end since
+// the tracked snapshot version is based on the migration index.
+// If there is a crash-inducing bug in an existing migration, it can be patched
+// in-place, but it should never be removed from the migrations array.
+const migrations = [
+  oldSnapshot => {
+    const { __unstable__, ...rest } = oldSnapshot;
+    return {
+      ...rest,
+      [veryLongKey]: __unstable__
+    };
+  }
+];
+
 export function getStateSnapshot(state) {
   const {
     paused,
@@ -16,7 +34,8 @@ export function getStateSnapshot(state) {
     __playlist__
   } = state;
   return {
-    __unstable__: {
+    [versionKey]: migrations.length,
+    [veryLongKey]: {
       paused,
       currentTime,
       activeTrackIndex,
@@ -34,6 +53,9 @@ export function getStateSnapshot(state) {
 }
 
 export function restoreStateFromSnapshot(snapshot, props) {
+  const migratedSnapshot = migrations
+    .slice(snapshot[versionKey] || 0)
+    .reduce((oldSnapshot, migration) => migration(oldSnapshot), snapshot);
   const {
     paused,
     currentTime,
@@ -45,7 +67,7 @@ export function restoreStateFromSnapshot(snapshot, props) {
     shuffle,
     playbackRate,
     activeTrackSrc
-  } = snapshot.__unstable__;
+  } = migratedSnapshot[veryLongKey];
   const restoredStateValues = {};
   if (isPlaylistValid(props.playlist) && typeof paused === 'boolean') {
     // using awaitingPlay instead of paused triggers an animation


### PR DESCRIPTION
Closes #366.

* Change internals key in snapshot so it's much more unwieldy to use.
* Set up migration system so snapshots from old versions of Cassette will update gracefully.
* Allow snapshot restores to fail without causing Cassette to crash
  * This case may be unavoidable if an app downgrades its Cassette version after deploying to users